### PR TITLE
Prevent macro wrong place in hierarchy (only at the bottom)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stripper_interface"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
 
 description = "This is the library used by rustdoc-stripper and gir to generate comments files."


### PR DESCRIPTION
cc @gkoz
